### PR TITLE
[CICD] #104. 이미지를 태그를 lastest -> commit SHA 기반 태그로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,15 +28,15 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t ${{ secrets.ECR_REPO }}:latest .
+          docker build -t ${{ secrets.ECR_REPO }}:${{ github.sha }} .
 
       - name: Tag Docker image
         run: |
-          docker tag ${{ secrets.ECR_REPO }}:latest ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO }}:latest
+          docker tag ${{ secrets.ECR_REPO }}:${{ github.sha }} ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO }}:${{ github.sha }}
 
       - name: Push Docker image to ECR
         run: |
-          docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO }}:latest
+          docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO }}:${{ github.sha }}
 
       - name: Deploy to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
@@ -51,3 +51,4 @@ jobs:
             SPRING_DATASOURCE_URL=${{ secrets.RDS_URL }}
             SPRING_DATASOURCE_USERNAME=${{ secrets.RDS_USERNAME }}
             SPRING_DATASOURCE_PASSWORD=${{ secrets.RDS_PASSWORD }}
+            IMAGE_TAG=${{ github.sha }}


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- latest로 이미지 태그를 고정해뒀는데 ECR에서 이미지 태그 불변을 활성화해서 덮어쓰기가 안 되서 문제 발생
- GitHub Actions에서 버전 태그 사용(commit SHA 기반 태그)
- AWS ECR에서 lifecycle policy 규칙 생성 완료
   - 정책: 최근 10개만 이미지 태그 유지(나머지는 삭제)

## 🔗 관련 이슈
- Closes #104 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
