### PR TITLE
[프로필 관리] #127 ConversationRepository 쿼리 오류 수정

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/conversation/repository/ConversationRepository.java
+++ b/src/main/java/com/codeit/playlist/domain/conversation/repository/ConversationRepository.java
@@ -24,9 +24,9 @@ public interface ConversationRepository extends JpaRepository<Conversation, UUID
     LEFT JOIN FETCH c.user1 u1
     LEFT JOIN FETCH c.user2 u2
     WHERE (c.user1.id = :currentUserId OR c.user2.id = :currentUserId)
-      AND (:keyword IS NULL OR u1.name LIKE %:keyword% OR u2.name LIKE %:keyword%)
+      AND (:#{#keyword == null} = true OR u1.name LIKE CONCAT('%', :keyword, '%') OR u2.name LIKE CONCAT('%', :keyword, '%'))
       AND (
-            :cursor IS NULL
+            :#{#cursor == null} = true
             OR (c.createdAt < :cursor)
             OR (c.createdAt = :cursor AND c.id < :idAfter)
           )
@@ -46,9 +46,9 @@ public interface ConversationRepository extends JpaRepository<Conversation, UUID
     LEFT JOIN FETCH c.user1 u1
     LEFT JOIN FETCH c.user2 u2
     WHERE (c.user1.id = :currentUserId OR c.user2.id = :currentUserId)
-      AND (:keyword IS NULL OR u1.name LIKE %:keyword% OR u2.name LIKE %:keyword%)
+      AND (:#{#keyword == null} = true OR u1.name LIKE CONCAT('%', :keyword, '%') OR u2.name LIKE CONCAT('%', :keyword, '%'))
       AND (
-            :cursor IS NULL
+            :#{#cursor == null} = true
             OR (c.createdAt > :cursor)
             OR (c.createdAt = :cursor AND c.id > :idAfter)
           )
@@ -66,7 +66,7 @@ public interface ConversationRepository extends JpaRepository<Conversation, UUID
         SELECT COUNT(c)
         FROM Conversation c
         WHERE (c.user1.id = :currentUserId OR c.user2.id = :currentUserId)
-          AND (:keyword IS NULL OR c.user1.name LIKE %:keyword% OR c.user2.name LIKE %:keyword%)
+          AND (:#{#keyword == null} = true OR c.user1.name LIKE CONCAT('%', :keyword, '%') OR c.user2.name LIKE CONCAT('%', :keyword, '%'))
         """)
   long countAll(@Param("currentUserId") UUID currentUserId, @Param("keyword") String keyword);
 }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- keyword 뿐만 아니라 null 체크 방식도 변경
- null 체크 방식
   - cursor 값이 null 일때와 아닐때의 구분을 확실히 함
   - 이전: (:cursor IS NULL ...)
   - 변경: (:#{#cursor == null} = true ...)
- keyword 인식 오류 (CONCAT 사용)
   - 표준 JPQL로 고침
   - 이전: LIKE %:keyword%
   - 변경: LIKE CONCAT('%', :keyword, '%')

## 🔗 관련 이슈
- Closes #127 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
