### PR TITLE
[CICD] #149. 띄어쓰기로 인해 jq가 필터 문자열을 못 받아서  GitHub Actions에서 workflows 오류 발생

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
             --arg ACCOUNT_ID "${{ secrets.AWS_ACCOUNT_ID }}" \
             --arg REDIS_PASSWORD "${{ secrets.REDIS_PASSWORD }}" \
              '.executionRoleArn |= sub("ACCOUNT_ID_PLACEHOLDER"; $ACCOUNT_ID)
-              | .taskRoleArn |= sub("ACCOUNT_ID_PLACEHOLDER"; $ACCOUNT_ID) 
+              | .taskRoleArn |= sub("ACCOUNT_ID_PLACEHOLDER"; $ACCOUNT_ID)
               | .containerDefinitions[1].environment[0].value = $REDIS_PASSWORD' \
              task-definition.json > tmp.json && mv tmp.json task-definition.json
 


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 띄어쓰기로 인해 jq가 필터 문자열을 못 받아서  GitHub Actions에서 workflows 오류 발생
- 불필요한 띄어쓰기와 줄바꿈 기호를 삭제하여 문제 해결

## 🔗 관련 이슈
- Closes #149 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
