### PR TITLE
[CICD] #152. $REDIS_PASSWORD를 jq 변수 -> 문자열로 인식하도록 수정

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -33,7 +33,7 @@
       "name": "playlist-redis",
       "image": "redis:7.2",
       "essential": false,
-      "command": ["sh", "-c", "redis-server --requirepass $REDIS_PASSWORD"],
+      "command": ["sh", "-c", "redis-server --requirepass \\$REDIS_PASSWORD"],
       "portMappings": [
         {
           "containerPort": 6379,


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- $REDIS_PASSWORD를 jq 변수 -> 문자열로 인식하도록 수정하여 $REDIS_PASSWORD is not defined at <top-level> 해결

## 🔗 관련 이슈
- Closes #152 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
