### PR TITLE
[CICD] #158. 메서드 파라미터로 환경변수를 주입해서 RedissonClient 빈 생성 실패문제 해결

### DIFF
--- a/src/main/java/com/codeit/playlist/global/config/RateLimitConfig.java
+++ b/src/main/java/com/codeit/playlist/global/config/RateLimitConfig.java
@@ -9,25 +9,18 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RateLimitConfig {
-
-  @Value("${spring.data.redis.host:localhost}")
-  private String redisHost;
-
-  @Value("${spring.data.redis.port:6379}")
-  private int redisPort;
-
-  @Value("${spring.data.redis.password:}")
-  private String redisPassword;
-
-  @Bean
-  public RedissonClient redissonClient() {
-    Config config = new Config();
-    var serverConfig = config.useSingleServer()
-        .setAddress(String.format("redis://%s:%d", redisHost, redisPort));
-    if (!redisPassword.isEmpty()) {
-      serverConfig.setPassword(redisPassword);
+    @Bean
+    public RedissonClient redissonClient(
+            @Value("${spring.data.redis.host:localhost}") String host,
+            @Value("${spring.data.redis.port:6379}") int port,
+            @Value("${spring.data.redis.password:}") String password) {
+        Config config = new Config();
+        var serverConfig = config.useSingleServer()
+                .setAddress(String.format("redis://%s:%d", host, port));
+        if (!password.isEmpty()) {
+            serverConfig.setPassword(password);
+        }
+        return Redisson.create(config);
     }
-    return Redisson.create(config);
-  }
 
 }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 메서드 파라미터로 환경변수를 주입해서 RedissonClient 빈 생성 실패문제 해결
- 환경변수는 정확히 주입이 됐는데도 에러 발생
   - @Value private field로 주입하면 빈 생성 메서드를 호출할 때 환경변수 값이 null일 수 있음
   - 메서드 파라미터 주입방식으로 바꿔서 빈 생성 시점에 제대로 환경변수 값이 들어갈 수 있도록 함

## 🔗 관련 이슈
- Closes #158 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
