### PR TITLE
[CICD] #167. redis와 app이 같은 컨터이너에서 실행되므로 localhost로 접속

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
                 {"name": "LOGS_BUCKET", "value": $LOGS_BUCKET},
                 {"name": "PROFILE_BUCKET", "value": $PROFILE_BUCKET},
                 {"name": "CONTENT_BUCKET", "value": $CONTENT_BUCKET},
-                {"name": "REDIS_HOST", "value": "playlist-redis"},
+                {"name": "REDIS_HOST", "value": "localhost"},
                 {"name": "REDIS_PASSWORD", "value": $REDIS_PASSWORD},
                 {"name": "REDIS_PORT", "value": "6379"},
                 {"name": "SPRING_MAIL_HOST", "value": $SPRING_MAIL_HOST},


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- redis와 app이 같은 컨터이너에서 실행되므로 localhost로 접속하도록 수정
- Fargate에서 이름 기반 DNS를 지원하지 않으므로 playlist-redis -> localhost로 수정

## 🔗 관련 이슈
- Closes #167 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
