### PR TITLE
[플레이리스트] #269 플레이리스트 추가 시 오류 메시지가 뜨는 문제 해결

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/codeit/playlist/domain/playlist/controller/PlaylistController.java
@@ -97,7 +97,7 @@ public class PlaylistController {
             @RequestParam(required = false) UUID subscriberIdEqual,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) UUID idAfter,
-            @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int limit,
             @RequestParam(defaultValue = "DESCENDING") SortDirection sortDirection,  //DESENDING, ASCENDING
             @RequestParam(defaultValue = "updatedAt") PlaylistSortBy sortBy  //updatedAt, subscribeCount
             ) {


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 콘텐츠 단건 조회에서 '플레이리스트 추가' 버튼을 클릭 시 '플레이 리스트를 불러오는데 실패했습니다'라는 오류 메시지가 뜨는 문제를 해결하였습니다.

## 🔗 관련 이슈
- Closes #269 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
