### PR TITLE
[콘텐츠 데이터 관리] #250 콘텐츠 데이터 중복처리 구현

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/content/api/response/TheMovieResponse.java
+++ b/src/main/java/com/codeit/playlist/domain/content/api/response/TheMovieResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public record TheMovieResponse(
+        @JsonProperty("id") Long tmdbId,
         @JsonProperty("title") String title,
         @JsonProperty("overview") String description,
         @JsonProperty("poster_path") String thumbnailUrl,

--- a/src/main/java/com/codeit/playlist/domain/content/api/service/TheMovieApiService.java
+++ b/src/main/java/com/codeit/playlist/domain/content/api/service/TheMovieApiService.java
@@ -26,7 +26,7 @@ public class TheMovieApiService {
     private String apikey; // tmdb API key
 
     private final int firstPage = 1;
-    private final int maxPage = 3;
+    private final int maxPage = 2;
 
     private Mono<TheMovieListResponse> callTheMovieApi(String query, String path, int page) {
         log.info("[콘텐츠 데이터 관리] TheMovie API Mono 빌드 시작, callTheMovieApi query : {}, path : {}", query, path);

--- a/src/main/java/com/codeit/playlist/domain/content/batch/ContentTasklet.java
+++ b/src/main/java/com/codeit/playlist/domain/content/batch/ContentTasklet.java
@@ -6,6 +6,8 @@ import com.codeit.playlist.domain.content.api.service.TheMovieApiService;
 import com.codeit.playlist.domain.content.entity.Content;
 import com.codeit.playlist.domain.content.entity.Tag;
 import com.codeit.playlist.domain.content.entity.Type;
+import com.codeit.playlist.domain.content.exception.ContentBadRequestException;
+import com.codeit.playlist.domain.content.exception.ContentNotFoundException;
 import com.codeit.playlist.domain.content.repository.ContentRepository;
 import com.codeit.playlist.domain.content.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +54,15 @@ public class ContentTasklet implements Tasklet {
             String thumbnailUrl = movieResponse.thumbnailUrl();
             if(thumbnailUrl != null && !thumbnailUrl.isBlank()) {
                 content.setThumbnailUrl("https://image.tmdb.org/t/p/w500" + thumbnailUrl);
+            }
+            if(movieResponse.tmdbId() == null) {
+                log.warn("[콘텐츠 데이터 관리] 콘텐츠가 존재하지 않습니다. tmdbId가 null입니다.");
+                continue;
+            }
+            Long tmdbId = movieResponse.tmdbId();
+            if(contentRepository.existsByTmdbId(tmdbId)) {
+                log.warn("[콘텐츠 데이터 관리] 콘텐츠 데이터가 이미 존재합니다. tmdbId : {}", movieResponse.tmdbId());
+                continue;
             }
             Content resultContent = contentRepository.save(content); // 썸네일까지 set된 content
 

--- a/src/main/java/com/codeit/playlist/domain/content/entity/Content.java
+++ b/src/main/java/com/codeit/playlist/domain/content/entity/Content.java
@@ -19,6 +19,12 @@ import lombok.NoArgsConstructor;
 public class Content extends BaseUpdatableEntity {
 
     /**
+     * TMDB ID
+     */
+    @Column(unique = true)
+    private Long tmdbId;
+
+    /**
      * 컨텐츠 타입
      */
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/codeit/playlist/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/codeit/playlist/domain/content/repository/ContentRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface ContentRepository extends JpaRepository<Content, UUID>, ContentRepositoryCustom {
-
+    boolean existsByTmdbId(Long tmdbId);
 }

--- a/src/main/java/com/codeit/playlist/domain/content/service/basic/BasicContentService.java
+++ b/src/main/java/com/codeit/playlist/domain/content/service/basic/BasicContentService.java
@@ -57,8 +57,9 @@ public class BasicContentService implements ContentService {
         if(thumbnail == null || thumbnail.isBlank()) {
             throw new ContentBadRequestException("썸네일은 필수입니다.");
         }
-
+        Long uuid = UUID.randomUUID().getLeastSignificantBits();
         Content content = new Content(
+                uuid,
                 type,
                 request.title(),
                 request.description(),
@@ -240,7 +241,7 @@ public class BasicContentService implements ContentService {
         log.info("[콘텐츠 데이터 관리] nextIdAfter : {}", nextIdAfter);
 
         CursorResponseContentDto responseDto = new CursorResponseContentDto(data, nextCursor, nextIdAfter, hasNext, pageSize, sortBy, sortDirection);
-        log.debug("[콘텐츠 데이터 관리] 커서 페이지네이션 컨텐츠 수집 완료, response = {}", responseDto);
+        log.debug("[콘텐츠 데이터 관리] 커서 페이지네이션 컨텐츠 수집 완료");
         return responseDto;
     }
 


### PR DESCRIPTION
콘텐츠 데이터를 조회할 때 중복되는 부분이 있으면 DB에 적재하지 않습니다. 
content 클래스에 새로운 필드가 추가되었습니다.

## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 콘텐츠 데이터를 중복검사하는 로직입니다. content 엔티티에 필드가 추가되었습니다.

## 🔗 관련 이슈
- Closes #250 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
