### PR TITLE
[CICD] docker compose 환경에서 DB를 못 찾는 문제

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER}" ]
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- DB에 헬스 체크 추가 후 헬스 체크 명령에서 DB이름을 지정하지 않아 유저이름과 DB명이 같다고 봐서 오류 발생
- 명시적으로 유저이름과 DB이름을 작성해서 문제 해결

## 🔗 관련 이슈
- Closes #313 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
