### PR TITLE
[사용자 관리] #316 로그아웃시 SSE 연결 끊기

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/auth/service/basic/BasicAuthService.java
+++ b/src/main/java/com/codeit/playlist/domain/auth/service/basic/BasicAuthService.java
@@ -189,7 +189,7 @@ public class BasicAuthService implements AuthService {
       UUID userId = jwtTokenProvider.getUserId(refreshToken);
       jwtRegistry.invalidateJwtInformationByUserId(userId);
 
-      sseEmitterRepository.closeByUserId(userId);
+      sseEmitterRepository.delete(userId);
     }
     jwtRegistry.revokeByToken(refreshToken);
     log.info("[인증 관리] : 로그아웃 완료");

--- a/src/main/java/com/codeit/playlist/domain/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/com/codeit/playlist/domain/sse/repository/SseEmitterRepository.java
@@ -67,7 +67,4 @@ public class SseEmitterRepository {
     }
   }
 
-  public void closeByUserId(UUID userId) {
-    delete(userId);
-  }
 }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- sse의 생명주기보다 빠르게 다른 계정으로 로그인하면 시청자 목록에 변경되기 전 아이디로 남아있는 오류가 있었습니다.
- SseEmitterRepository 에 연결 종료용 메서드를 추가하고, logout 로직에 sse 연결 종료 로직을 추가했습니다.

## 🔗 관련 이슈
- Closes #316 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
