### PR TITLE
[플레이리스트] #328 deledAt을 Instant로 변경함에 따라 쿼리문 수정

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/codeit/playlist/domain/playlist/repository/PlaylistRepository.java
@@ -22,12 +22,12 @@ public interface PlaylistRepository extends JpaRepository<Playlist, UUID>, Playl
 
     // Soft delete
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-        update Playlist p 
-           set p.deletedAt = CURRENT_TIMESTAMP 
-         where p.id = :playlistId 
-           and p.deletedAt is null
-    """)
+    @Query(value = """
+        update playlists
+           set deletedAt = now() 
+         where id = :playlistId 
+           and deleted_at is null
+    """, nativeQuery = true)
     int softDeleteById(@Param("playlistId") UUID playlistId);
 
     // 7일 지난 soft delete 대상 조회


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- Entity의 deletedAt을 LocalDateTime에서 Instant로 변경함에 따라 nativeQuery를 사용하여 CURRENT_TIMESTAMP에서 now()를 쓰도록 변경하였습니다.

## 🔗 관련 이슈
- Closes #328 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
