### PR TITLE
[플레이리스트] #328 동작하지 않는 쿼리문 수정(deletedAt문제)

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/codeit/playlist/domain/playlist/repository/PlaylistRepository.java
@@ -24,7 +24,7 @@ public interface PlaylistRepository extends JpaRepository<Playlist, UUID>, Playl
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
         update playlists
-           set deletedAt = now() 
+           set deleted_at = now() 
          where id = :playlistId 
            and deleted_at is null
     """, nativeQuery = true)


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 쿼리문의 set deletedAt을 인식하지 못하는 문제를 발견하여 deleted_at으로 변경

## 🔗 관련 이슈
- Closes #328 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
