### PR TITLE
[CICD] #332. S3에서 이미지 조회 안되던 문제 해결

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/file/S3Uploader.java
+++ b/src/main/java/com/codeit/playlist/domain/file/S3Uploader.java
@@ -13,8 +13,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 /*
  * 콘텐츠와 프로필 이미지는 GetObject 요청에 대해서만 Public 함
@@ -37,7 +35,7 @@ public class S3Uploader {
 
             s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
 
-            return generateFileUrl(bucket, key);
+            return generatePublicUrl(bucket, key);
         } catch (Exception e) {
             log.error("[S3] S3에 파일 업로드 실패: key={}, bucket={}, errorMessage={}", key, bucket, e.getMessage(), e);
             throw FailUploadToS3Exception.withBucket(bucket);
@@ -73,8 +71,7 @@ public class S3Uploader {
         }
     }
 
-    private String generateFileUrl(String bucket, String key) {
-        String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8).replace("+", "%20");
-        return "https://" + bucket + ".s3." + s3Properties.getRegion() + ".amazonaws.com/" + encodedKey;
+    private String generatePublicUrl(String bucket, String key) {
+        return "https://" + bucket + ".s3." + s3Properties.getRegion() + ".amazonaws.com/" + key;
     }
 }

--- a/src/main/java/com/codeit/playlist/domain/user/service/basic/BasicUserService.java
+++ b/src/main/java/com/codeit/playlist/domain/user/service/basic/BasicUserService.java
@@ -16,24 +16,13 @@ import com.codeit.playlist.domain.user.dto.request.UserUpdateRequest;
 import com.codeit.playlist.domain.user.dto.response.CursorResponseUserDto;
 import com.codeit.playlist.domain.user.entity.Role;
 import com.codeit.playlist.domain.user.entity.User;
-import com.codeit.playlist.domain.user.exception.EmailAlreadyExistsException;
-import com.codeit.playlist.domain.user.exception.NewPasswordRequired;
-import com.codeit.playlist.domain.user.exception.PasswordMustCharacters;
-import com.codeit.playlist.domain.user.exception.UserLockStateUnchangedException;
-import com.codeit.playlist.domain.user.exception.UserNameRequiredException;
-import com.codeit.playlist.domain.user.exception.UserNotFoundException;
-import com.codeit.playlist.domain.user.exception.UserProfileAccessDeniedException;
+import com.codeit.playlist.domain.user.exception.*;
 import com.codeit.playlist.domain.user.mapper.UserMapper;
 import com.codeit.playlist.domain.user.repository.UserRepository;
 import com.codeit.playlist.domain.user.repository.UserRepositoryCustom;
 import com.codeit.playlist.domain.user.service.UserService;
 import com.codeit.playlist.global.constant.S3Properties;
 import com.codeit.playlist.global.redis.TemporaryPasswordStore;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,6 +33,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -269,7 +264,7 @@ public class BasicUserService implements UserService {
       }
 
       String extension = contentType.equals("image/png") ? ".png" : ".jpg";
-      String key = "profile/" + UUID.randomUUID() + extension;
+      String key = UUID.randomUUID() + extension;
 
       String imageUrl = s3Uploader.upload(
           s3Properties.getProfileBucket(),


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- S3 업로드 시 불필요한 인코딩을 제거하여 S3에서 이미지 조회 안되던 문제 해결
- 불필요한 폴더명 제거

## 🔗 관련 이슈
- Closes #332 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- https://www.notion.so/2c5a7ba35b118097b271ddce03e863f1?source=copy_link

## 🙋 리뷰어에게 요청사항
- 서버를 내려놔서 아직 정확한 확인은 안됐습니다.
서버가 다시 살아나면 확인하겠습니다.
