### PR TITLE
[사용자 관리] #331 운영환경에서 소셜 로그인 안되는 오류

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -41,7 +41,7 @@ spring:
 playlist:
   jwt:
     cookie:
-      secure: true
+      secure: false
 
 oauth2:
   redirect:


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 운영 환경에서 cookie secure 를 true 로 설정해두었는데, 실서비스 환경이 아니기 때문에 https:// 가 적용되지 않았습니다.
- 그렇기에 false로 변경하여 테스트합니다.

## 🔗 관련 이슈
- Closes #331 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
