### PR TITLE
[실시간 같이 보기] 잘못 정의된 ENUM 삭제

### DIFF
--- a/src/main/java/com/codeit/playlist/domain/watching/controller/WatchingController.java
+++ b/src/main/java/com/codeit/playlist/domain/watching/controller/WatchingController.java
@@ -2,7 +2,6 @@ package com.codeit.playlist.domain.watching.controller;
 
 import com.codeit.playlist.domain.base.SortDirection;
 import com.codeit.playlist.domain.watching.dto.data.WatchingSessionDto;
-import com.codeit.playlist.domain.watching.dto.data.WatchingSortBy;
 import com.codeit.playlist.domain.watching.dto.response.CursorResponseWatchingSessionDto;
 import com.codeit.playlist.domain.watching.service.WatchingService;
 import jakarta.validation.constraints.Max;
@@ -31,7 +30,7 @@ public class WatchingController {
                                                                                          @RequestParam(required = false) UUID idAfter,
                                                                                          @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit,
                                                                                          @RequestParam(defaultValue = "ASCENDING") SortDirection sortDirection,
-                                                                                         @RequestParam(defaultValue = "createdAt") WatchingSortBy sortBy) {
+                                                                                         @RequestParam(defaultValue = "createdAt") String sortBy) {
         log.debug("[실시간 같이 보기] 특정 콘텐츠의 시청 세션 목록 조회(커서 페이지네이션) 시작: " +
                         "contentId = {}, watcherNameLike = {}, cursor={}, idAfter={}, limit={}, sortDirection={}, sortBy={}",
                 contentId, watcherNameLike, cursor, idAfter, limit, sortDirection, sortBy);

--- a/src/main/java/com/codeit/playlist/domain/watching/dto/data/WatchingSortBy.java
+++ b/src/main/java/com/codeit/playlist/domain/watching/dto/data/WatchingSortBy.java
@@ -1,5 +1,0 @@
-package com.codeit.playlist.domain.watching.dto.data;
-
-public enum WatchingSortBy {
-    createdAt
-}

--- a/src/main/java/com/codeit/playlist/domain/watching/dto/response/CursorResponseWatchingSessionDto.java
+++ b/src/main/java/com/codeit/playlist/domain/watching/dto/response/CursorResponseWatchingSessionDto.java
@@ -1,7 +1,6 @@
 package com.codeit.playlist.domain.watching.dto.response;
 
 import com.codeit.playlist.domain.base.SortDirection;
-import com.codeit.playlist.domain.watching.dto.data.WatchingSortBy;
 import com.codeit.playlist.domain.watching.dto.data.WatchingSessionDto;
 
 import java.util.List;
@@ -13,7 +12,7 @@ public record CursorResponseWatchingSessionDto(
         UUID nextIdAfter,
         boolean hasNext,
         long totalCount,
-        WatchingSortBy sortBy,
+        String sortBy,
         SortDirection sortDirection
 ) {
 }

--- a/src/main/java/com/codeit/playlist/domain/watching/service/WatchingService.java
+++ b/src/main/java/com/codeit/playlist/domain/watching/service/WatchingService.java
@@ -1,7 +1,6 @@
 package com.codeit.playlist.domain.watching.service;
 
 import com.codeit.playlist.domain.base.SortDirection;
-import com.codeit.playlist.domain.watching.dto.data.WatchingSortBy;
 import com.codeit.playlist.domain.watching.dto.data.WatchingSessionDto;
 import com.codeit.playlist.domain.watching.dto.response.CursorResponseWatchingSessionDto;
 
@@ -14,7 +13,7 @@ public interface WatchingService {
                                                                   UUID idAfter,
                                                                   int limit,
                                                                   SortDirection sortDirection,
-                                                                  WatchingSortBy sortBy);
+                                                                  String sortBy);
 
     WatchingSessionDto getWatchingSessionByUser(UUID userId);
 }

--- a/src/main/java/com/codeit/playlist/domain/watching/service/basic/BasicWatchingService.java
+++ b/src/main/java/com/codeit/playlist/domain/watching/service/basic/BasicWatchingService.java
@@ -14,7 +14,6 @@ import com.codeit.playlist.domain.user.repository.UserRepository;
 import com.codeit.playlist.domain.watching.dto.data.RawWatchingSession;
 import com.codeit.playlist.domain.watching.dto.data.RawWatchingSessionPage;
 import com.codeit.playlist.domain.watching.dto.data.WatchingSessionDto;
-import com.codeit.playlist.domain.watching.dto.data.WatchingSortBy;
 import com.codeit.playlist.domain.watching.dto.response.CursorResponseWatchingSessionDto;
 import com.codeit.playlist.domain.watching.repository.RedisWatchingSessionRepository;
 import com.codeit.playlist.domain.watching.service.WatchingService;
@@ -45,7 +44,7 @@ public class BasicWatchingService implements WatchingService {
                                                                          UUID idAfter,
                                                                          int limit,
                                                                          SortDirection sortDirection,
-                                                                         WatchingSortBy sortBy) {
+                                                                         String sortBy) {
         log.debug("[실시간 같이 보기] 실시간 시청자 조회 시작: " +
                         "contentId = {}, watcherNameLike = {}, cursor={}, idAfter={}, limit={}, sortDirection={}, sortBy={}",
                 contentId, watcherNameLike, cursor, idAfter, limit, sortDirection, sortBy);

--- a/src/test/java/com/codeit/playlist/watching/controller/WatchingControllerTest.java
+++ b/src/test/java/com/codeit/playlist/watching/controller/WatchingControllerTest.java
@@ -2,7 +2,6 @@ package com.codeit.playlist.watching.controller;
 
 import com.codeit.playlist.domain.base.SortDirection;
 import com.codeit.playlist.domain.watching.controller.WatchingController;
-import com.codeit.playlist.domain.watching.dto.data.WatchingSortBy;
 import com.codeit.playlist.domain.watching.dto.data.WatchingSessionDto;
 import com.codeit.playlist.domain.watching.service.WatchingService;
 import com.codeit.playlist.watching.fixture.WatchingSessionFixtures;
@@ -38,7 +37,7 @@ class WatchingControllerTest {
         UUID idAfter = UUID.randomUUID();
         int limit = 10;
         SortDirection sortDirection = SortDirection.ASCENDING;
-        WatchingSortBy sortBy = WatchingSortBy.createdAt;
+        String sortBy = "createdAt";
 
         // when
         watchingController.getWatchingSessionsByContent(

--- a/src/test/java/com/codeit/playlist/watching/service/basic/BasicWatchingServiceTest.java
+++ b/src/test/java/com/codeit/playlist/watching/service/basic/BasicWatchingServiceTest.java
@@ -12,7 +12,6 @@ import com.codeit.playlist.domain.user.repository.UserRepository;
 import com.codeit.playlist.domain.watching.dto.data.RawWatchingSession;
 import com.codeit.playlist.domain.watching.dto.data.RawWatchingSessionPage;
 import com.codeit.playlist.domain.watching.dto.data.WatchingSessionDto;
-import com.codeit.playlist.domain.watching.dto.data.WatchingSortBy;
 import com.codeit.playlist.domain.watching.dto.response.CursorResponseWatchingSessionDto;
 import com.codeit.playlist.domain.watching.repository.RedisWatchingSessionRepository;
 import com.codeit.playlist.domain.watching.service.basic.BasicWatchingService;
@@ -85,7 +84,7 @@ class BasicWatchingServiceTest {
                 null,
                 10,
                 SortDirection.ASCENDING,
-                WatchingSortBy.createdAt);
+                "createdAt");
 
         // then
         verify(redisWatchingSessionRepository, times(1))


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- WatchingSortBy 삭제 후 관련 코드 수정
- ENUM에 표시되는 상수는 모드 대문자로 표시하여야하는데,FE와 createdAt과 같이 소문자로 소통해야 하기 때문에 ENUM을 사용할 수 없음

## 🔗 관련 이슈
- Closes #379 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
