### PR TITLE
[알림 및 콘텐츠 평가 및 큐레이팅] #399 @MockBean을 @MockitoBean으로 수정하고 PlaylistApplicationTests의 의존성 제거

### DIFF
--- a/src/test/java/com/codeit/playlist/PlaylistApplicationTests.java
+++ b/src/test/java/com/codeit/playlist/PlaylistApplicationTests.java
@@ -1,6 +1,5 @@
 package com.codeit.playlist;
 
-import com.codeit.playlist.domain.content.api.handler.TheSportsDateHandler;
 import com.codeit.playlist.domain.security.AdminInitializer;
 import com.codeit.playlist.domain.security.jwt.JwtTokenProvider;
 import com.codeit.playlist.global.config.TheSportsConfig;
@@ -21,9 +20,6 @@ class PlaylistApplicationTests {
 
     @MockitoBean
     private TheSportsConfig theSportsConfig;
-
-    @MockitoBean
-    private TheSportsDateHandler theSportsDateHandler;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;

--- a/src/test/java/com/codeit/playlist/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/codeit/playlist/notification/controller/NotificationControllerTest.java
@@ -9,7 +9,6 @@ import com.codeit.playlist.domain.user.dto.data.UserDto;
 import com.codeit.playlist.global.config.JpaConfig;
 import com.codeit.playlist.global.error.GlobalExceptionHandler;
 import com.codeit.playlist.global.error.InvalidSortByException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -29,6 +27,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -64,10 +63,7 @@ public class NotificationControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
+    @MockitoBean
     private NotificationService notificationService;
 
     //테스트용 SecurityConfig

--- a/src/test/java/com/codeit/playlist/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/codeit/playlist/playlist/controller/PlaylistControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -33,6 +32,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -70,13 +70,13 @@ public class PlaylistControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private PlaylistService playlistService;
 
-    @MockBean
+    @MockitoBean
     private PlaylistSubscriptionService playlistSubscriptionService;
 
-    @MockBean
+    @MockitoBean
     private PlaylistContentService playlistContentService;
 
     UUID userId = UUID.randomUUID();

--- a/src/test/java/com/codeit/playlist/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/codeit/playlist/review/controller/ReviewControllerTest.java
@@ -21,7 +21,6 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -34,6 +33,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -73,7 +73,7 @@ public class ReviewControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private ReviewService reviewService;
 
     //테스트용 SecurityConfig


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 알림 및 콘텐츠 평가, 큐레이팅 도메인의 Controller들에 있는 MockBean 어노테이션을 MockitoBean으로 변경하고 PlaylistApplicationTests의 TheSportsDateHandler 의존성을 제거한다.

## 🔗 관련 이슈
- Closes #399 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
