### PR TITLE
[CICD] 불필요한 hostPort 제거

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -17,7 +17,6 @@
       "portMappings": [
         {
           "containerPort": 8080,
-          "hostPort": 8080,
           "protocol": "tcp",
           "appProtocol": "http"
         }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- ECS(Fargate)에서 hostPort는 몰라도 된다.
- AWS가 알아서 ALB -> 임의 포트 -> container:8080으로 연결해준다.
- 따라서 삭제

## 🔗 관련 이슈
- Closes #380

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
