### PR TITLE
[CICD] 운영환경에 메일 발송을 통한 비밀번호 초기화가 안되는 문제를 AWS SES를 사용하여 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
             --arg SPRING_MAIL_PASSWORD "${{ secrets.SPRING_MAIL_PASSWORD }}" \
             --arg SPRING_MAIL_PORT "${{ secrets.SPRING_MAIL_PORT }}" \
             --arg SPRING_MAIL_USERNAME "${{ secrets.SPRING_MAIL_USERNAME }}" \
+            --arg SPRING_MAIL_FROM "${{ secrets.SPRING_MAIL_FROM }}" \
             --arg WEBSOCKET_ALLOWED_ORIGINS "${{ secrets.WEBSOCKET_ALLOWED_ORIGINS }}" \
             --arg SPORTSDB_API_KEY "${{ secrets.SPORTSDB_API_KEY }}" \
             --arg SPORTSDB_BASE_URL "${{ secrets.SPORTSDB_BASE_URL }}" \
@@ -104,6 +105,7 @@ jobs:
                 {"name": "SPRING_MAIL_PASSWORD", "value": $SPRING_MAIL_PASSWORD},
                 {"name": "SPRING_MAIL_PORT", "value": $SPRING_MAIL_PORT},
                 {"name": "SPRING_MAIL_USERNAME", "value": $SPRING_MAIL_USERNAME},
+                {"name": "SPRING_MAIL_FROM", "value": $SPRING_MAIL_FROM},
                 {"name": "WEBSOCKET_ALLOWED_ORIGINS", "value": $WEBSOCKET_ALLOWED_ORIGINS},
                 {"name": "SPORTSDB_API_KEY", "value": $SPORTSDB_API_KEY},
                 {"name": "SPORTSDB_BASE_URL", "value": $SPORTSDB_BASE_URL},

--- a/src/main/java/com/codeit/playlist/domain/auth/service/basic/BasicEmailService.java
+++ b/src/main/java/com/codeit/playlist/domain/auth/service/basic/BasicEmailService.java
@@ -3,6 +3,7 @@ package com.codeit.playlist.domain.auth.service.basic;
 import com.codeit.playlist.domain.auth.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -14,11 +15,14 @@ public class BasicEmailService implements EmailService {
 
   private final JavaMailSender mailSender;
 
+  @Value("${spring.mail.from}")
+  private String from;
+
   public void sendTemporaryPassword(String toEmail, String tempPassword) {
     try {
       log.debug("[메일] : 임시 비밀번호 이메일 전송 시작 - 수신자: {}", toEmail);
       SimpleMailMessage message = new SimpleMailMessage();
-      message.setFrom("dkswnddnjs517@gmail.com"); // SES Verified Email
+      message.setFrom(from); // SES Verified Email
       message.setTo(toEmail);
       message.setSubject("[Playlist] 임시 비밀번호 안내");
       message.setText(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,7 @@ spring:
     port: 587                   # SMTP 서버 포트
     username: ${SPRING_MAIL_USERNAME}                # SMTP 서버 로그인 아이디
     password: ${SPRING_MAIL_PASSWORD}                # SMTP 서버 로그인 비밀번호
+    from: ${SPRING_MAIL_FROM:no-reply@gmail.com}
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 로컬에서 되던 비밀번호 초기화 기능이 운영 환경에서는 안되는 문제 발생
- 운영서버에서는 Gmail SMTP 가 네트워크 및 보안 정책으로 차단되기 때문에 발생한 문제
- 같은 AWS 계정의 SES 를 사용해서 트랜잭션 메일을 발송하는 것이 정석이므로 그렇게 하고자 함
- 따라서 AWS SES계정의 샌드박스에서 도메인과 발송 이메일에 대한 자격증명을 받아서 운영환경에 환경변수로 전달
- message.setFrom(검증된 이메일) 추가

## 🔗 관련 이슈
- Closes #426 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
