### PR TITLE
[CICD] SMTP 서버가 HELO 거절하는 것을 해결하기 위해 host 추가

### DIFF
--- a/src/main/java/com/codeit/playlist/global/config/JavaMailSenderConfig.java
+++ b/src/main/java/com/codeit/playlist/global/config/JavaMailSenderConfig.java
@@ -1,11 +1,12 @@
 package com.codeit.playlist.global.config;
 
-import java.util.Properties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
 
 @Configuration
 public class JavaMailSenderConfig {
@@ -39,6 +40,7 @@ public class JavaMailSenderConfig {
     properties.setProperty("mail.smtp.auth", "true");
     properties.setProperty("mail.smtp.starttls.enable", "true");
     properties.setProperty("mail.smtp.ssl.enable","false");
+    properties.put("mail.smtp.localhost", "playlist-team1.me"); // 메일을 보내는 서버의 DNS
     return properties;
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
     import: optional:file:.env[.properties]
 
   mail:
-    host: smtp.gmail.com        # SMTP 서버 호스트
+    host: ${SPRING_MAIL_HOST}   # SMTP 서버 호스트
     port: 587                   # SMTP 서버 포트
     username: ${SPRING_MAIL_USERNAME}                # SMTP 서버 로그인 아이디
     password: ${SPRING_MAIL_PASSWORD}                # SMTP 서버 로그인 비밀번호


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 클라이언트 -> SES SMTP 서버 연결할 때 클라이언트가 HELO <hostname>을 보내는데 잘못된 값을 넣고 있었음
- 에러로그
```
org.springframework.mail.MailSendException: Mail server connection failed. Failed messages: jakarta.mail.MessagingException: 501 Syntax: HELO <hostname>
```

## 🔗 관련 이슈
- Closes #427 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
