### PR TITLE
[콘텐츠 데이터 관리] #429, #430, #431 테스트코드 및 CI deploy 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
 
 jobs:
   deploy:

--- a/src/main/java/com/codeit/playlist/domain/content/batch/ContentScheduler.java
+++ b/src/main/java/com/codeit/playlist/domain/content/batch/ContentScheduler.java
@@ -17,7 +17,7 @@ public class ContentScheduler {
     private final JobLauncher jobLauncher;
     private final Job contentJob;
 
-    @Scheduled(cron = "0 0 5 * * *") // 매일 오전 5시에 실행
+    @Scheduled(cron = "0 0 5 ? * SUN") // 매주 일요일 오전 5시에 실행
     public void runContentJob() {
         log.info("[콘텐츠 데이터 관리] API 배치 작업 시작");
         JobParameters jobParameters = new JobParametersBuilder()

--- a/src/test/java/com/codeit/playlist/content/service/api/service/TheSportApiServiceTest.java
+++ b/src/test/java/com/codeit/playlist/content/service/api/service/TheSportApiServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.net.URI;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/test/java/com/codeit/playlist/content/service/basic/BasicContentServiceTest.java
+++ b/src/test/java/com/codeit/playlist/content/service/basic/BasicContentServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/src/test/java/com/codeit/playlist/content/service/basic/BasicContentServiceTest.java
+++ b/src/test/java/com/codeit/playlist/content/service/basic/BasicContentServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.inOrder;
 
 import com.codeit.playlist.domain.base.SortDirection;
 import com.codeit.playlist.domain.content.dto.data.ContentDto;
@@ -37,6 +38,7 @@ import com.codeit.playlist.domain.content.service.basic.BasicContentService;
 import com.codeit.playlist.domain.file.S3Uploader;
 import com.codeit.playlist.domain.playlist.repository.PlaylistContentRepository;
 import com.codeit.playlist.domain.playlist.repository.PlaylistRepository;
+import com.codeit.playlist.domain.review.repository.ReviewRepository;
 import com.codeit.playlist.domain.watching.repository.RedisWatchingSessionRepository;
 import com.codeit.playlist.global.constant.S3Properties;
 import org.junit.jupiter.api.DisplayName;
@@ -44,10 +46,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -72,6 +76,8 @@ public class BasicContentServiceTest {
     private PlaylistRepository playlistRepository;
     @Mock
     private PlaylistContentRepository playlistContentRepository;
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @Nested
     @DisplayName("create()")
@@ -141,10 +147,7 @@ public class BasicContentServiceTest {
         void create_fail_typeNull() {
             // given
             ContentCreateRequest request = new ContentCreateRequest(
-                    null,
-                    "t",
-                    "d",
-                    List.of("tag")
+                    null, "t", "d", List.of("tag")
             );
             MultipartFile thumbnail = new MockMultipartFile(
                     "thumbnail", "a.jpg", "image/jpeg", "x".getBytes(StandardCharsets.UTF_8)
@@ -153,7 +156,7 @@ public class BasicContentServiceTest {
             // when & then
             assertThatThrownBy(() -> contentService.create(request, thumbnail))
                     .isInstanceOf(ContentBadRequestException.class)
-                    .hasMessageContaining("타입");
+                    .hasMessageContaining("컨텐츠에 대한 잘못된 요청입니다."); // ✅ 실제 메시지 기준
 
             then(contentRepository).shouldHaveNoInteractions();
             then(tagRepository).shouldHaveNoInteractions();
@@ -174,7 +177,7 @@ public class BasicContentServiceTest {
             // when & then
             assertThatThrownBy(() -> contentService.create(request, null))
                     .isInstanceOf(ContentBadRequestException.class)
-                    .hasMessageContaining("썸네일");
+                    .hasMessageContaining("컨텐츠에 대한 잘못된 요청입니다.");
 
             then(contentRepository).shouldHaveNoInteractions();
             then(tagRepository).shouldHaveNoInteractions();
@@ -198,7 +201,7 @@ public class BasicContentServiceTest {
             // when & then
             assertThatThrownBy(() -> contentService.create(request, empty))
                     .isInstanceOf(ContentBadRequestException.class)
-                    .hasMessageContaining("썸네일");
+                    .hasMessageContaining("컨텐츠에 대한 잘못된 요청입니다.");
 
             then(contentRepository).shouldHaveNoInteractions();
             then(tagRepository).shouldHaveNoInteractions();
@@ -303,7 +306,7 @@ public class BasicContentServiceTest {
     class DeleteTests {
 
         @Test
-        @DisplayName("성공: 존재하면 playlist-content 삭제 + 태그 삭제 + content 삭제")
+        @DisplayName("성공: 존재하면 리뷰->플리컨텐츠->태그 삭제 후 컨텐츠 삭제")
         void delete_success() {
             // given
             UUID contentId = UUID.randomUUID();
@@ -312,14 +315,23 @@ public class BasicContentServiceTest {
             // when
             contentService.delete(contentId);
 
-            // then
-            then(playlistContentRepository).should(times(1)).deleteAllByContent_Id(contentId);
-            then(tagRepository).should(times(1)).deleteAllByContentId(contentId);
-            then(contentRepository).should(times(1)).deleteById(contentId);
+            // then (호출 순서까지 검증)
+            InOrder inOrder = inOrder(contentRepository, reviewRepository, playlistContentRepository, tagRepository);
+
+            inOrder.verify(contentRepository).existsById(contentId);
+            inOrder.verify(reviewRepository).deleteAllByContent_Id(contentId);
+            inOrder.verify(playlistContentRepository).deleteAllByContent_Id(contentId);
+            inOrder.verify(tagRepository).deleteAllByContentId(contentId);
+            inOrder.verify(contentRepository).deleteById(contentId);
+
+            // 불필요한 추가 호출 방지 (선택)
+            then(reviewRepository).shouldHaveNoMoreInteractions();
+            then(playlistContentRepository).shouldHaveNoMoreInteractions();
+            then(tagRepository).shouldHaveNoMoreInteractions();
         }
 
         @Test
-        @DisplayName("실패: 없으면 ContentNotFoundException")
+        @DisplayName("실패: 존재하지 않으면 ContentNotFoundException + 아무것도 삭제 안 함")
         void delete_fail_notFound() {
             // given
             UUID contentId = UUID.randomUUID();
@@ -329,9 +341,10 @@ public class BasicContentServiceTest {
             assertThatThrownBy(() -> contentService.delete(contentId))
                     .isInstanceOf(ContentNotFoundException.class);
 
+            then(reviewRepository).shouldHaveNoInteractions();
             then(playlistContentRepository).shouldHaveNoInteractions();
             then(tagRepository).shouldHaveNoInteractions();
-            then(contentRepository).should(never()).deleteById(any());
+            then(contentRepository).should(never()).deleteById(contentId);
         }
     }
 
@@ -348,25 +361,36 @@ public class BasicContentServiceTest {
             given(request.sortDirection()).willReturn(SortDirection.DESCENDING);
             given(request.sortBy()).willReturn("watcherCount");
 
-            // searchContents는 limit+1(=3)개를 가져온다고 가정
+            // ✅ UUID를 직접 주입 (List.of(null, ..) 방지)
+            UUID id1 = UUID.randomUUID();
+            UUID id2 = UUID.randomUUID();
+            UUID id3 = UUID.randomUUID();
+
             Content c1 = new Content(1L, "movie", "t1", "d1", "k1", 0, 0, 0);
             Content c2 = new Content(2L, "movie", "t2", "d2", "k2", 0, 0, 0);
             Content c3 = new Content(3L, "movie", "t3", "d3", "k3", 0, 0, 0);
 
+            // id 필드명이 보통 "id"라서 이렇게 박으면 됨
+            ReflectionTestUtils.setField(c1, "id", id1);
+            ReflectionTestUtils.setField(c2, "id", id2);
+            ReflectionTestUtils.setField(c3, "id", id3);
+
+            // searchContents는 limit+1(=3)개를 가져온다고 가정
             List<Content> found = List.of(c1, c2, c3);
             given(contentRepository.searchContents(eq(request), eq(false), eq(2), eq("watcherCount")))
                     .willReturn(found);
 
-            // N+1 방지 태그 로딩
-            List<UUID> firstTwoIds = List.of(c1.getId(), c2.getId());
+            // 태그: 실제 로직은 (firstTwoIds) 기준으로 findByContentIdIn 호출
+            List<UUID> firstTwoIds = List.of(id1, id2);
             Tag t11 = new Tag(c1, "액션");
             Tag t21 = new Tag(c2, "드라마");
-            given(tagRepository.findByContentIdIn(argThat(ids -> ids.containsAll(firstTwoIds) && ids.size() == 2)))
+
+            given(tagRepository.findByContentIdIn(eq(firstTwoIds)))
                     .willReturn(List.of(t11, t21));
 
             // watcherCount: c1=1, c2=5
-            given(redisWatchingSessionRepository.countWatchingSessionByContentId(c1.getId())).willReturn(1L);
-            given(redisWatchingSessionRepository.countWatchingSessionByContentId(c2.getId())).willReturn(5L);
+            given(redisWatchingSessionRepository.countWatchingSessionByContentId(id1)).willReturn(1L);
+            given(redisWatchingSessionRepository.countWatchingSessionByContentId(id2)).willReturn(5L);
 
             ContentDto dto1 = mock(ContentDto.class);
             ContentDto dto2 = mock(ContentDto.class);
@@ -385,7 +409,7 @@ public class BasicContentServiceTest {
 
             // nextCursor는 "이번 페이지 마지막 요소(c2)의 watcherCount"
             assertThat(res.nextCursor()).isEqualTo("5");
-            assertThat(res.nextIdAfter()).isEqualTo(c2.getId().toString());
+            assertThat(res.nextIdAfter()).isEqualTo(id2.toString());
         }
 
         @Nested

--- a/src/test/java/com/codeit/playlist/content/service/basic/BasicTagServiceTest.java
+++ b/src/test/java/com/codeit/playlist/content/service/basic/BasicTagServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.*;
 
 import reactor.core.publisher.Mono;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -181,12 +182,20 @@ class BasicTagServiceTest {
         void saveSportTag_success_filtersNullBlank() {
             // given
             Content content = content();
+            List<String> tagNames = Arrays.asList("Soccer", " ", null, "EPL");
 
             // when
-            tagService.saveTheSportTagToContent(content, List.of("Soccer", " ", null, "EPL"));
+            tagService.saveTheSportTagToContent(content, tagNames);
 
-            // then: "Soccer", "EPL"만 저장
-            then(tagRepository).should(times(2)).save(any(Tag.class));
+            // then
+            ArgumentCaptor<Tag> captor = ArgumentCaptor.forClass(Tag.class);
+            then(tagRepository).should(times(2)).save(captor.capture());
+
+            List<String> savedNames = captor.getAllValues().stream()
+                    .map(Tag::getName)   // ⚠️ Tag의 getter 이름이 다르면 맞춰줘 (예: getTagName)
+                    .toList();
+
+            assertThat(savedNames).containsExactly("Soccer", "EPL");
         }
 
         @Test


### PR DESCRIPTION
## PR 제목 규칙
[도메인] 이슈카드번호 PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 콘텐츠 데이터와 관련된 테스트코드를 수정하여 컨벤션에서 정한 JaCoCo 테스트 커버리지를 준수합니다.
- deploy.yml을 수정하여 develop에 push되어도 Actions가 돌아가지 않게끔 합니다.

## 🔗 관련 이슈
- Closes #429, #430, #431 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
